### PR TITLE
Added gnome-print-sharp-2.18 dependency

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -69,6 +69,16 @@ AC_SUBST(GTK_SHARP_LIBS)
 gtksharp_prefix=`pkg-config --variable=prefix gtk-sharp-2.0`
 AC_SUBST(gtksharp_prefix)
 
+PKG_CHECK_MODULES(GNOMEPRINT_SHARP, gnome-print-sharp-2.18, use_gnomeprint=yes, use_gnomeprint=no)
+if test "x$use_gnomeprint" = "xyes" ; then
+GNOMEPRINT_SHARP_REQUIRES=gnome-print-sharp-2.18
+else
+GNOMEPRINT_SHARP_REQUIRES=
+fi
+AC_SUBST(GNOMEPRINT_SHARP_CFLAGS)
+AC_SUBST(GNOMEPRINT_SHARP_LIBS)
+AC_SUBST(GNOMEPRINT_SHARP_REQUIRES)
+
 PKG_CHECK_MODULES(GTKSOURCEVIEW, gtksourceview-1.0 >= 1.0.0)
 AC_SUBST(GTKSOURCEVIEW_LIBS)
 gtksourceview_prefix=`pkg-config --variable=prefix gtksourceview-1.0`

--- a/gtksourceview-sharp-2.0.pc.in
+++ b/gtksourceview-sharp-2.0.pc.in
@@ -6,5 +6,5 @@ libdir=@libdir@
 Name: GtkSourceView#
 Description: GtkSourceView# - gtksourceview .NET Binding
 Version: @VERSION@
-Requires: gnome-sharp-2.0
+Requires: gnome-sharp-2.0 @GNOMEPRINT_SHARP_REQUIRES@
 Libs: -r:${prefix}/lib/mono/gtksourceview-sharp-2.0/gtksourceview-sharp.dll

--- a/sample/Makefile.am
+++ b/sample/Makefile.am
@@ -10,5 +10,5 @@ $(TEST): $(srcdir)/SourceViewTest.cs
 	$(CSC) -out:$@ $(srcdir)/SourceViewTest.cs -r:../gtksourceview/gtksourceview-sharp.dll -pkg:gtk-sharp-2.0
 
 $(PRINT): $(srcdir)/PrintSample.cs
-	$(CSC) -out:$@ $(srcdir)/PrintSample.cs -r:../gtksourceview/gtksourceview-sharp.dll -pkg:gtk-sharp-2.0 -pkg:gnome-sharp-2.0
+	$(CSC) -out:$@ $(srcdir)/PrintSample.cs -r:../gtksourceview/gtksourceview-sharp.dll -pkg:gtk-sharp-2.0 -pkg:gnome-sharp-2.0 $(GNOMEPRINT_SHARP_LIBS)
 


### PR DESCRIPTION
This is a patch from @openSUSE that hasn't been forwarded upstream yet.
